### PR TITLE
run travis across supported versions of rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,9 @@ rvm:
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-18mode
   - rbx-19mode
-script: rspec spec
+
+gemfile:
+  - gemfiles/3.0.gemfile
+  - gemfiles/3.1.gemfile
+  - gemfiles/3.2.gemfile
+  - Gemfile

--- a/gemfiles/3.0.gemfile
+++ b/gemfiles/3.0.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 3.0.12"
+gem 'rspec', '>= 2.8.0'
+
+gemspec :path=>"../"

--- a/gemfiles/3.1.gemfile
+++ b/gemfiles/3.1.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 3.1.4"
+gem 'rspec', '>= 2.8.0'
+
+gemspec :path=>"../"

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 3.2.3"
+gem 'rspec', '>= 2.8.0'
+
+gemspec :path=>"../"


### PR DESCRIPTION
also: travis defaults to 'rake' for script, so it's not needed
