### PR TITLE
Support NullUser pattern as well as AnonymousUser pattern.

### DIFF
--- a/lib/authority.rb
+++ b/lib/authority.rb
@@ -32,7 +32,7 @@ module Authority
   # @raise [SecurityViolation] if user is not allowed to perform action on resource
   # @return [Model] resource instance
   def self.enforce(action, resource, user, options = {})
-    unless action_authorized?(action, resource, user, options)
+    unless !(user.nil? or configuration.nil_anonymous_users) && action_authorized?(action, resource, user, options)
       raise SecurityViolation.new(user, action, resource)
     end
     resource
@@ -40,7 +40,7 @@ module Authority
 
   def self.action_authorized?(action, resource, user, options = {})
     resource_and_maybe_options = [resource, options].tap {|args| args.pop if args.last == {}}
-    user and user.send("can_#{action}?", *resource_and_maybe_options)
+    user.send("can_#{action}?", *resource_and_maybe_options)
   end
 
   class << self

--- a/lib/authority/configuration.rb
+++ b/lib/authority/configuration.rb
@@ -3,7 +3,7 @@ module Authority
 
     # Has default settings, which can be overridden in the initializer.
 
-    attr_accessor :abilities, :controller_action_map, :user_method, :security_violation_handler, :logger
+    attr_accessor :abilities, :controller_action_map, :user_method, :nil_anonymous_users, :security_violation_handler, :logger
 
     def initialize
 
@@ -25,6 +25,7 @@ module Authority
       }
 
       @user_method = :current_user
+      @nil_anonymous_users = false
 
       @security_violation_handler = :authority_forbidden
 

--- a/lib/generators/templates/authority_initializer.rb
+++ b/lib/generators/templates/authority_initializer.rb
@@ -9,7 +9,17 @@ Authority.configure do |config|
   # Default is:
   #
   # config.user_method = :current_user
-  
+  #
+  # NIL_ANONYMOUS_USERS
+  # -------------------
+  # If your `user_method` method returns nil for unauthenticated users, you'll probably want
+  # Authority to treat them as anonymous users with no permissions, so set this to `true`.
+  # Otherwise, Authority will raise errors when the result of `user_method` is nil.
+  #
+  # Default is:
+  #
+  # config.nil_anonymous_users = false
+
   # CONTROLLER_ACTION_MAP
   # =====================
   # For a given controller method, what verb must a user be able to do?
@@ -33,7 +43,7 @@ Authority.configure do |config|
   # ABILITIES
   # =========
   # Teach Authority how to understand the verbs and adjectives in your system. Perhaps you
-  # need {:microwave => 'microwavable'}. I'm not saying you do, of course. Stop looking at 
+  # need {:microwave => 'microwavable'}. I'm not saying you do, of course. Stop looking at
   # me like that.
   #
   # Defaults are as follows:
@@ -48,7 +58,7 @@ Authority.configure do |config|
   # LOGGER
   # ======
   # If a user tries to perform an unauthorized action, where should we log that fact?
-  # Provide a logger object which responds to `.warn(message)`, unless your 
+  # Provide a logger object which responds to `.warn(message)`, unless your
   # security_violation_handler calls a different method.
   #
   # Default is:

--- a/spec/authority/configuration_spec.rb
+++ b/spec/authority/configuration_spec.rb
@@ -11,6 +11,10 @@ describe Authority::Configuration do
       expect(Authority.configuration.user_method).to eq(:current_user)
     end
 
+    it "does not treat nil `user_method` results as unauthorized" do
+      expect(Authority.configuration.nil_anonymous_users).to be_false
+    end
+
     describe "logging security violations" do
 
       it "logs to standard error by default" do

--- a/spec/authority_spec.rb
+++ b/spec/authority_spec.rb
@@ -61,16 +61,17 @@ describe Authority do
 
     end
 
-    it "raises a SecurityViolation if the user is nil" do
-      expect { Authority.enforce(:update, resource_class, nil) }.to raise_error(Authority::SecurityViolation)
-    end
-
     it "raises a SecurityViolation if the action is unauthorized" do
       expect { Authority.enforce(:update, resource_class, user) }.to raise_error(Authority::SecurityViolation)
     end
 
     it "doesn't raise a SecurityViolation if the action is authorized" do
       expect { Authority.enforce(:read, resource_class, user) }.not_to raise_error(Authority::SecurityViolation)
+    end
+
+    it "raises a SecurityViolation if the user is nil and nil_anonymous_users are allowed" do
+      Authority.configuration.stub(:nil_anonymous_users){ true }
+      expect { Authority.enforce(:update, resource_class, nil) }.to raise_error(Authority::SecurityViolation)
     end
 
   end


### PR DESCRIPTION
Allows `action_authorized?` to handle nil `send(Authority.configuration.user_method)` users without raising `undefined method 'can_#{action}?' for nil:NilClass`, but `SecurityViolation` instead.

This works well for lightweight authentication systems that don't mock out a user when unauthenticated.

I meant for this to be a one-liner fix, but my text editor must have trimmed off a trailing space somewhere. Darn.
