### PR TITLE
class method .resource

### DIFF
--- a/lib/authority/abilities.rb
+++ b/lib/authority/abilities.rb
@@ -45,14 +45,29 @@ module Authority
 
       # @return [Class] of the designated authorizer
       def authorizer
-        @authorizer ||= authorizer_name.constantize # Get an actual reference to the authorizer class
+        @authorizer ||= wrap_authorizer(authorizer_name) # Get an actual reference to the authorizer class
       rescue NameError
         raise Authority::NoAuthorizerError.new(
           "#{authorizer_name} is set as the authorizer for #{self}, but the constant is missing"
         )
       end
 
-    end
+      def wrap_authorizer(authorizer_name)
+        wraper_name = self.name.to_s + 'AuthorizerWraper'
 
+        begin
+          wraper_name.constantize
+        rescue
+          resource_class = self
+          wraper_class = Class.new(authorizer_name.constantize) do
+                           @resource = resource_class
+                           def self.resource
+                             @resource
+                           end
+                         end
+          Object.const_set(wraper_name, wraper_class)
+        end
+      end
+    end
   end
 end

--- a/spec/authority/abilities_spec.rb
+++ b/spec/authority/abilities_spec.rb
@@ -48,15 +48,15 @@ describe Authority::Abilities do
 
     describe "authorizer" do
 
-      it "constantizes the authorizer name as the authorizer" do
+      it "wraps the authorizer with wraper" do
         resource_class.instance_variable_set(:@authorizer, nil)
-        resource_class.authorizer_name.should_receive(:constantize)
+        resource_class.should_receive(:wrap_authorizer)
         resource_class.authorizer
       end
 
       it "memoizes the authorizer to avoid reconstantizing" do
         resource_class.authorizer
-        resource_class.authorizer_name.should_not_receive(:constantize)
+        resource_class.should_not_receive(:wrap_authorizer)
         resource_class.authorizer
       end
 
@@ -69,6 +69,26 @@ describe Authority::Abilities do
 
     end
 
+  end
+
+  context 'authorizer wraper' do
+    specify 'authorizer should be wraped with wraper class' do
+      resource_class.authorizer.name.should == 'ExampleResourceAuthorizerWraper'
+    end
+
+    specify 'authorizer wraper name for application authorither should be uniq' do
+      other_resource_class.authorizer.name.should == 'OtherResourceAuthorizerWraper'
+    end
+
+    describe '.resourse' do
+      specify 'resource class should respond to .resourse' do
+        resource_class.authorizer.should respond_to(:resource)
+      end
+
+      specify '.resource should return resource class' do
+        resource_class.authorizer.resource.should == resource_class
+      end
+    end
   end
 
   describe "class methods" do


### PR DESCRIPTION
There are some cases when it is nesessary to carry resourse to class method in authorizer. For example we have:

```
class ApplicationAuthorizer < Authority::Authorizer
  def self.readable_by?(user)
    user.has_permission?(:read, resource)
  end
end
```

When we call `Comment.readable_by?(user)`, we call `ApplicationAuthorizer.readable_by?(user)`, and in `readable_by?` method we have no connection with model it is called on.

The easiest way is to send it as param to method call, but there can be some compatibility issues with earlier versions of gem.

 Here i tryed to wrap authorizer class with another class where i define a class instance variable with resource class through flat scope. I'm not quite sure if this approach is the best way to carry resource class to authorizer. What do you think?
