### PR TITLE
Correctly set authorizer=

### DIFF
--- a/lib/authority/abilities.rb
+++ b/lib/authority/abilities.rb
@@ -23,9 +23,6 @@ module Authority
       end
     end
 
-    def authorizer=(authorizer_class)
-      @authorizer = authorizer_class
-    end
 
     def authorizer
       self.class.authorizer.new(self) # instantiate on every check, in case model has changed
@@ -43,6 +40,11 @@ module Authority
 
     module ClassMethods
       include Definitions
+
+      def authorizer=(authorizer_class)
+        @authorizer = authorizer_class
+        self.authorizer_name = @authorizer.name
+      end
 
       # @return [Class] of the designated authorizer
       def authorizer

--- a/spec/authority/abilities_spec.rb
+++ b/spec/authority/abilities_spec.rb
@@ -46,6 +46,26 @@ describe Authority::Abilities do
 
     end
 
+    describe "authorizer=" do
+
+      let(:test_class)  { Class.new {include Authority::Abilities} }
+
+      it "has a class attribute=" do
+        expect(test_class).to respond_to(:authorizer=)
+      end
+
+      it "sets authorizer" do
+        test_class.authorizer = ExampleResourceAuthorizer
+        expect(test_class.authorizer).to eq(ExampleResourceAuthorizer)
+      end
+
+      it "sets authorizer_name" do
+        test_class.authorizer = ExampleResourceAuthorizer
+        expect(test_class.authorizer_name).to eq("ExampleResourceAuthorizer")
+      end
+
+    end
+
     describe "authorizer" do
 
       it "constantizes the authorizer name as the authorizer" do


### PR DESCRIPTION
When I blow away my original changes, the specs got removed as well, so they happily passed when the `authorize=` was not set correctly. 3rd time is the charm I suppose.

Additionally, `authorizer=` now sets the `authorizer_name` so they both will stay sync.
