### PR TITLE
Fix failing spec. Proc.bind was removed in Rails 4.1.

### DIFF
--- a/spec/authority/controller_spec.rb
+++ b/spec/authority/controller_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'support/example_classes'
 require 'support/mock_rails'
-require 'active_support/core_ext/proc'
 require 'set'
 
 describe Authority::Controller do


### PR DESCRIPTION
Build fails with:

> /home/travis/build/nathanl/authority/spec/authority/controller_spec.rb:4:in `require': cannot load such file -- active_support/core_ext/proc (LoadError)

In issue #56 `Proc.bind` was replaced with `instance_exec`, but the controller spec still requires that `Proc` class. That file was removed in Rails 4.1 which raises an error now.
