### PR TITLE
Fix README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -281,11 +281,11 @@ describe AdminAuthorizer do
 
   describe "class" do
     it "lets admins update in bulk" do
-      expect(AdminAuthorizer).to be_bulk_updatable_by(@admin)
+      expect(AdminAuthorizer).to be_updatable_by(@admin)
     end
 
     it "doesn't let users update in bulk" do
-      expect(AdminAuthorizer).not_to be_bulk_updatable_by(@user)
+      expect(AdminAuthorizer).not_to be_updatable_by(@user)
     end
   end
 


### PR DESCRIPTION
## Fix methods called on AdminAuthorizer

The testing section of the README refers to the method bulk_updatable_by(). After trying to add tests it seems that the methods defined on the class are still just updatable_by() [NOTE: lack of bulk_ prefix] like the instance methods. Feel free to ignore the PR if I'm mistaken.

PS. Thanks for a cool gem. It's really helping me keep code cleaner and more readable.
