### PR TITLE
instance default method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -121,6 +121,9 @@ The authorization process generally flows like this:
 
 If the answer is `false` and the original caller was a controller, this is treated as a `SecurityViolation`. If it was a view, maybe you just don't show a link.
 
+The authorization process for instances is different in that it calls the instances `default` method before calling the class `default` method. This allows to
+define default behaviour that requires access to the model instance to be determined.
+
 (Diagrams made with [AsciiFlow](http://asciiflow.com))
 
 <a name="installation">

--- a/lib/authority/authorizer.rb
+++ b/lib/authority/authorizer.rb
@@ -20,21 +20,30 @@ module Authority
       false
     end
 
-    # Each instance method simply calls the corresponding class method
-    Authority.adjectives.each do |adjective|
-      def_delegator :"self.class", :"#{adjective}_by?"
+    # the instance default method calls the class default method
+    def default(adjective, user, options = {})
+      user_and_maybe_options = self.class.send(:user_and_maybe_options, user, options)
+      self.class.send(:"#{adjective}_by?", *user_and_maybe_options)
     end
 
-    # Each class method simply calls the `default` method
+    # Each method simply calls the `default` method (instance or class)
     Authority.adjectives.each do |adjective|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def self.#{adjective}_by?(user, options = {})
-          user_and_maybe_options = [user, options].tap {|args| args.pop if args.last == {}}
+          default(:#{adjective}, *user_and_maybe_options(user, options))
+        end
+
+        def #{adjective}_by?(user, options = {})
+          user_and_maybe_options = self.class.send(:user_and_maybe_options, user, options)
           default(:#{adjective}, *user_and_maybe_options)
         end
       RUBY
     end
 
+    def self.user_and_maybe_options(user, options = {})
+      [user, options].tap {|args| args.pop if args.last == {}}
+    end
+    private_class_method :user_and_maybe_options
   end
 
   class NoAuthorizerError < StandardError ; end

--- a/spec/authority/authorizer_spec.rb
+++ b/spec/authority/authorizer_spec.rb
@@ -13,6 +13,20 @@ describe Authority::Authorizer do
 
   describe "instance methods" do
 
+    it "calls the instance default method if no instance method is defined" do
+      expect(authorizer).to receive(:default)
+      authorizer.creatable_by?(user)
+    end
+
+    context "the instance default method" do
+
+      it "delegates to the class default method" do
+        expect(authorizer.class).to receive(:default)
+        authorizer.default(:creatable, user)
+      end
+
+    end
+
     Authority.adjectives.each do |adjective|
       method_name = "#{adjective}_by?"
 


### PR DESCRIPTION
there's currently no way to handle handle default behaviour if access to the model instance is required to figure out if access should be allowed or denied.

This introduces an instance default method that, by default, just calls the classes ability method.
It also uses the same logic to pass on or remove options if the ability methods are called with or without options accordingly. 

One example where I'm using this is to only allow access to admin users for objects that are not yet "published". 