### PR TITLE
Add support for Array arguments to `authority_actions`

### DIFF
--- a/lib/authority/controller.rb
+++ b/lib/authority/controller.rb
@@ -114,6 +114,9 @@ module Authority
       authority_action = self.class.authority_action_map[action_name.to_sym]
       if authority_action.nil?
         raise MissingAction.new("No authority action defined for #{action_name}")
+      elsif authority_action.kind_of?(Array)
+        options = authority_action[1..-1]
+        authority_action = authority_action.first
       end
 
       Authority.enforce(authority_action, authority_resource, authority_user, *options)

--- a/spec/authority/controller_spec.rb
+++ b/spec/authority/controller_spec.rb
@@ -344,6 +344,13 @@ describe Authority::Controller do
           controller_instance.send(:authorize_action_for, resource_class, options)
         end
 
+        it "passes options set by authority_actions" do
+          options = {:for => 'insolence'}
+          controller_class.authority_actions({:destroy => ['delete', options]})
+          Authority.should_receive(:enforce).with('delete', resource_class, user, options)
+          controller_instance.send(:authorize_action_for, resource_class)
+        end
+
         it "sets correct authorization flag" do
           Authority.stub(:enforce)
           controller_instance.send(:authorize_action_for, resource_class)


### PR DESCRIPTION
This allows you to set options on the controller-level `authority_actions`, like:

```ruby
authority_actions :show => ['read', {:scope => :basic}], :show_details => ['read', {:scope => :advanced}]
```

Currently working on a pretty complicated project that requires fine-grained authorization on different actions in the same controller, this seemed like a more elegant solution than using separate `before_action` methods and pass options in there.

I'm not sure if you want to merge this or not, but if you do, I'd be happy to update the documentation too.