### PR TITLE
Fix travis-ci settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ gemfile:
   - gemfiles/3.2.gemfile
   - gemfiles/4.0.gemfile
   - gemfiles/4.1.gemfile
+  - gemfiles/4.2.gemfile
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
   - jruby-19mode # JRuby in 1.9 mode
   - rbx-2
 

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 3.2.3"
-gem 'rspec', '>= 2.8.0'
+gem 'rspec', '~> 2.14.0'
 
 gemspec :path=>"../"

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "rails", "~> 3.2.3"
+gem 'rails', '~> 3.2.3'
 gem 'rspec', '~> 2.14.0'
 
-gemspec :path=>"../"
+gemspec path: '../'

--- a/gemfiles/3.2.gemfile
+++ b/gemfiles/3.2.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem "rails", "~> 3.2.3"
 gem 'rspec', '~> 2.14.0'

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "rails", "~> 4.0.0"
+gem 'rails', '~> 4.0.0'
 gem 'rspec', '~> 2.14.0'
 
-gemspec :path=>"../"
+gemspec path: '../'

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem "rails", "~> 4.0.0"
 gem 'rspec', '~> 2.14.0'

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails", "~> 4.0"
-gem 'rspec', '~> 2.14'
+gem "rails", "~> 4.0.0"
+gem 'rspec', '~> 2.14.0'
 
 gemspec :path=>"../"

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem "rails", "~> 4.1.0"
 gem 'rspec', '~> 2.14.0'

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "rails", "~> 4.1.0"
+gem 'rails', '~> 4.1.0'
 gem 'rspec', '~> 2.14.0'
 
-gemspec :path=>"../"
+gemspec path: '../'

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem "rails", "~> 4.1"
-gem 'rspec', '~> 2.14'
+gem "rails", "~> 4.1.0"
+gem 'rspec', '~> 2.14.0'
 
 gemspec :path=>"../"

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem "rails", "~> 4.2.0"
+gem 'rails', '~> 4.2.0'
 gem 'rspec', '~> 2.14.0'
 
-gemspec :path=>"../"
+gemspec path: '../'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'https://rubygems.org'
 
 gem "rails", "~> 4.2.0"
 gem 'rspec', '~> 2.14.0'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,0 +1,6 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 4.2.0"
+gem 'rspec', '~> 2.14.0'
+
+gemspec :path=>"../"


### PR DESCRIPTION
- chore(travis-ci): test against ruby 2.2
- chore(travis-ci): fix dependency version
    - '~> 4.0' equals '>= 4.0', '< 5.0'
- chore(travis-ci): test against rails v4.2
- chore(travis-ci): use https as rubygems source
- style(gemfile): fix by rubocop