### PR TITLE
fixed link to Pivotal Labs access control blog post

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -493,7 +493,7 @@ Your method will be handed the `SecurityViolation`, which has a `message` method
 
 - [adamhunter](https://github.com/adamhunter) for pairing with me on this gem. The only thing faster than his typing is his brain.
 - [kevmoo](https://github.com/kevmoo), [MP211](https://github.com/MP211), and [scottmartin](https://github.com/scottmartin) for pitching in.
-- [nkallen](https://github.com/nkallen) for writing [a lovely blog post on access control](http://pivotallabs.com/users/nick/blog/articles/272-access-control-permissions-in-rails) when he worked at Pivotal Labs. I cried sweet tears of joy when I read that a couple of years ago. I was like, "Zee access code, she is so BEEUTY-FUL!"
+- [nkallen](https://github.com/nkallen) for writing [a lovely blog post on access control](http://blog.pivotal.io/labs/labs/access-control-permissions-in-rails-access-control-permissions-in-rails) when he worked at Pivotal Labs. I cried sweet tears of joy when I read that a couple of years ago. I was like, "Zee access code, she is so BEEUTY-FUL!"
 - [jnunemaker](https://github.com/jnunemaker) for later creating [Canable](http://github.com/jnunemaker/canable), another inspiration for Authority.
 - [TMA](http://www.tma1.com) for employing me and letting me open source some of our code.
 


### PR DESCRIPTION
I just started reading about Authority and really like what I see. I noticed that the link to the Pivotal article on Access Control was broken so I thought I'd do my part to help out.