### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -405,7 +405,7 @@ class LlamasController < ApplicationController
 end
 ```
 
-If you want to authorize all actions the same way, use the special `all_actions` hash key. For instance, if you have nested resources, you might say "you're allowed to do anything you like with an employee if you're allowed to update their organization".
+If you want to authorize all actions the same way, use the special `all_actions` hash key. For instance, if you have nested resources, you might say "you're allowed to do anything you like with an employee if you're allowed to update their employer".
 
 ```ruby
 class EmployeesController < ApplicationController


### PR DESCRIPTION
Hi :)

I was reading the readme and got to the example of using the `all_actions` method in controllers. I was momentarily confused by the reference to the organisation of a user when I could not find that in the code. I figured it might give people who are completely new to authority an extra few synapses if the example and the description referred to the same. 

This just changes the reference to *organisation* to *employer*. 

Hope you have a great day and thanks for what looks like an awesome gem. I am going to spend the rest of the day building it into my app. 