### PR TITLE
Only test MRI 2.3 and Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2
+  - 2.3.1
 
 gemfile:
-  - gemfiles/3.2.gemfile
-  - gemfiles/4.0.gemfile
-  - gemfiles/4.1.gemfile
-  - gemfiles/4.2.gemfile
-
-matrix:
-  exclude:
-    - rvm: rbx
-      gemfile: gemfiles/4.0.gemfile
+  - gemfiles/5.0.gemfile

--- a/gemfiles/4.0.gemfile
+++ b/gemfiles/4.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.0.0'
-gem 'rspec', '~> 2.14.0'
-
-gemspec path: '../'

--- a/gemfiles/4.1.gemfile
+++ b/gemfiles/4.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'rspec', '~> 2.14.0'
-
-gemspec path: '../'

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.2.0'
-gem 'rspec', '~> 2.14.0'
-
-gemspec path: '../'

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 3.2.3'
-gem 'rspec', '~> 2.14.0'
+gem 'rails', '~> 5.0'
+gem 'rspec', '~> 3.4'
 
 gemspec path: '../'


### PR DESCRIPTION
Other versions may still work; this is just to reduce the
headache of testing, given limited time.